### PR TITLE
Add refetching of gas fee and balances + modify gas calculating/warning

### DIFF
--- a/context/Globals.tsx
+++ b/context/Globals.tsx
@@ -4,7 +4,7 @@ import { WRAPPED_POCKET_ABI } from "@/utils/abis";
 import { ETH_CHAIN_ID, POKT_CHAIN_ID, POKT_MULTISIG_ADDRESS, POKT_RPC_URL, WPOKT_ADDRESS } from "@/utils/constants";
 import { getDataSource } from "@/datasource";
 import { isValidEthAddress } from "@/utils/misc";
-import { HStack, Link, Text, useToast } from "@chakra-ui/react";
+import { HStack, Link, Text, useInterval, useToast } from "@chakra-ui/react";
 import { typeGuard } from "@pokt-network/pocket-js";
 import { createContext, useContext, useEffect, useState } from "react";
 import { getAddress } from "viem";
@@ -185,6 +185,12 @@ export function GlobalContextProvider({ children }: any) {
             getActiveBridgeRequests(address)
         }
     }, [address])
+
+    useInterval(() => {
+        if (poktAddress) {
+            getPoktBalance()
+        }
+    }, 120000)
 
     function resetProgress() {
         setPoktTxHash("")


### PR DESCRIPTION
UX touch ups to keep gas fee data and balances up-to-date every 30-120 seconds. Also no longer triggers the gas estimate error icon if POKT balance is too low. Felt redundant and led to confusion. The error icon now only displays for insufficient ETH balances that may not cover gas.