### PR TITLE
Allowed receiving recipient filter from request on burns endpoints (active and all)

### DIFF
--- a/lib/burn.ts
+++ b/lib/burn.ts
@@ -50,8 +50,12 @@ export const getAllBurnsFromSenderAndOrRecipient = async (senderEthAddress?: str
       .find(
         {
           wpokt_address: WPOKT_ADDRESS.toLowerCase(),
-          sender_address: senderEthAddress ? senderEthAddress.toLowerCase() : undefined,
-          recipient_address: recipientPoktAddress ? recipientPoktAddress.toLowerCase() : undefined,
+          ...(senderEthAddress && {
+            sender_address: senderEthAddress,
+          }),
+          ...(recipientPoktAddress && {
+            recipient_address: recipientPoktAddress,
+          }),
         },
         { sort: { created_at: -1 } },
       )

--- a/lib/burn.ts
+++ b/lib/burn.ts
@@ -41,7 +41,7 @@ export const getAllBurns = async (): Promise<Burn[]> => {
   }
 };
 
-export const getAllBurnsFromSender = async (ethAddress: string): Promise<Burn[]> => {
+export const getAllBurnsFromSenderAndOrRecipient = async (senderEthAddress?: string, recipientPoktAddress?: string): Promise<Burn[]> => {
   try {
     const client = await dbPromise;
 
@@ -50,7 +50,8 @@ export const getAllBurnsFromSender = async (ethAddress: string): Promise<Burn[]>
       .find(
         {
           wpokt_address: WPOKT_ADDRESS.toLowerCase(),
-          sender_address: ethAddress.toLowerCase(),
+          sender_address: senderEthAddress ? senderEthAddress.toLowerCase() : undefined,
+          recipient_address: recipientPoktAddress ? recipientPoktAddress.toLowerCase() : undefined,
         },
         { sort: { created_at: -1 } },
       )

--- a/lib/burn.ts
+++ b/lib/burn.ts
@@ -51,10 +51,10 @@ export const getAllBurnsFromSenderAndOrRecipient = async (senderEthAddress?: str
         {
           wpokt_address: WPOKT_ADDRESS.toLowerCase(),
           ...(senderEthAddress && {
-            sender_address: senderEthAddress,
+            sender_address: senderEthAddress.toLowerCase(),
           }),
           ...(recipientPoktAddress && {
-            recipient_address: recipientPoktAddress,
+            recipient_address: recipientPoktAddress.toLowerCase(),
           }),
         },
         { sort: { created_at: -1 } },

--- a/pages/api/burns/active.ts
+++ b/pages/api/burns/active.ts
@@ -1,18 +1,20 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
-import { getAllBurnsFromSender } from '@/lib/burn';
+import { getAllBurnsFromSenderAndOrRecipient } from '@/lib/burn';
 import { Status } from '@/types';
 
 const findAll = async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method !== 'GET') return res.status(405).end();
 
-  const { sender } = req.query;
+  const { sender, recipient } = req.query;
 
-  if (typeof sender !== 'string' || !sender) return res.status(400).end();
+  if (!sender && !recipient) {
+    return res.status(400).end()
+  }
 
   try {
-    const burns = await getAllBurnsFromSender(sender);
-    
+    const burns = await getAllBurnsFromSenderAndOrRecipient(sender as string, recipient as string);
+
     if (!burns) return res.status(204).end();
     const activeBurns = burns.filter(burn => burn.status !== Status.SUCCESS && burn.status !== Status.FAILED);
 

--- a/pages/api/burns/all.ts
+++ b/pages/api/burns/all.ts
@@ -1,16 +1,18 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
-import { getAllBurnsFromSender } from '@/lib/burn';
+import { getAllBurnsFromSenderAndOrRecipient } from '@/lib/burn';
 
 const findAll = async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method !== 'GET') return res.status(405).end();
 
-  const { sender } = req.query;
+  const { sender, recipient } = req.query;
 
-  if (typeof sender !== 'string' || !sender) return res.status(400).end();
+  if (!sender && !recipient) {
+    return res.status(400).end()
+  }
 
   try {
-    const burns = await getAllBurnsFromSender(sender);
+    const burns = await getAllBurnsFromSenderAndOrRecipient(sender as string, recipient as string);
 
     if (!burns) return res.status(204).end();
 


### PR DESCRIPTION
I allowed passing the recipient as a filter in /active and /all burns endpoints. 

There is the option of passing both the sender and recipient to use both as a filter or just pass one of them to use it as a filter. If none of them is passed, the request is answered with a 400 HTTP Status Code.