### PR TITLE
Add troubleshoot text for ad blocker issues

### DIFF
--- a/components/Bridge.tsx
+++ b/components/Bridge.tsx
@@ -644,6 +644,11 @@ export function Bridge() {
                     </Center>
                 </Container>
             )}
+            <Container paddingY={2} textAlign={"center"} fontSize={10}>
+                <Text>
+                    If having trouble, please disable ad blockers and refresh this page. We don't serve ads but they may prevent the modals from popping up.
+                </Text>
+            </Container>
             <ResumeWrapModal
                 isOpen={isResumeMintOpen}
                 onClose={onResumeMintClose}

--- a/components/Bridge.tsx
+++ b/components/Bridge.tsx
@@ -646,7 +646,7 @@ export function Bridge() {
             )}
             <Container paddingY={2} textAlign={"center"} fontSize={10}>
                 <Text>
-                    If having trouble, please disable ad blockers and refresh this page. We don't serve ads but they may prevent the modals from popping up.
+                    If having trouble, please disable ad blockers and refresh this page. We don&apos;t serve ads but they may prevent the modals from popping up.
                 </Text>
             </Container>
             <ResumeWrapModal

--- a/components/Bridge.tsx
+++ b/components/Bridge.tsx
@@ -644,8 +644,8 @@ export function Bridge() {
                     </Center>
                 </Container>
             )}
-            <Container paddingY={2} textAlign={"center"} fontSize={10}>
-                <Text>
+            <Container paddingY={4} borderRadius={4} fontSize={10} bg="darkOverlay">
+                <Text textAlign="center">
                     If having trouble, please disable ad blockers and refresh this page. We don&apos;t serve ads but they may prevent the modals from popping up.
                 </Text>
             </Container>


### PR DESCRIPTION
This a helpful text for users coming across issues with the bridge due to their ad blocker for some reason. Here is how it displays in the UI:

![wpokt-frontend-adblocker-notice](https://github.com/pokt-network/wpokt-frontend/assets/54918343/1431bfc7-c0c1-418d-964b-ec20b49872da)
