### PR TITLE
Change rpc base url to patch issue and remove websocket

### DIFF
--- a/components/modal/ConnectPoktModal.tsx
+++ b/components/modal/ConnectPoktModal.tsx
@@ -10,7 +10,7 @@ export function ConnectPoktModal(props: ModalProps) {
 
     const poktWalletOptions = [
         {
-            name: "SendWallet / NodeWallet",
+            name: "NodeWallet",
             onConnect: () => {
                 connectSendWallet()
             }

--- a/context/Globals.tsx
+++ b/context/Globals.tsx
@@ -363,6 +363,7 @@ export function GlobalContextProvider({ children }: any) {
                         return 0;
                     }
                     balance = balanceResponse?.balance?.toString();
+                    console.log("POKT Balance: ", balance)
                 // } else {
                 //     // Get uPokt Balance
                 //     balance = await window.pocketNetwork

--- a/context/Transport.tsx
+++ b/context/Transport.tsx
@@ -63,6 +63,7 @@ export function TransportProvider({ children }: any) {
     const pocket = new AppPokt(transport);
     setPocketApp(pocket);
     await setPoktAddressToLedger(pocket)
+    console.log("Initialized pokt app")
     return pocket;
   }, []);
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -26,7 +26,7 @@ const config = createConfig({
   autoConnect: true,
   connectors,
   publicClient,
-  webSocketPublicClient
+  // webSocketPublicClient
 })
 
 export default function App({ Component, pageProps }: AppProps) {

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -21,7 +21,7 @@ if (POKT_CHAIN_ID !== "testnet" && POKT_CHAIN_ID !== "mainnet") {
   );
 }
 
-export const POKT_RPC_URL = POKT_CHAIN_ID === "testnet" ? "https://node2.testnet.pokt.network" : `https://mainnet.rpc.grove.city/v1/lb/${POKT_RPC_KEY}`
+export const POKT_RPC_URL = POKT_CHAIN_ID === "testnet" ? "https://node2.testnet.pokt.network" : `https://mainnet.rpc.grove.city/v1/${POKT_RPC_KEY}`
 
 export const POKT_MULTISIG_ADDRESS =
   process.env.NEXT_PUBLIC_POKT_MULTISIG_ADDRESS ||
@@ -59,18 +59,18 @@ export const ETH_RPC_CONFIG: JsonRpcProviderConfig = {
     switch (chain.id) {
       case goerli.id:
         return {
-          http: `https://eth-goerli.rpc.grove.city/v1/lb/${POKT_RPC_KEY}`,
-          webSocket: `wss://eth-goerli.rpc.grove.city/v1/lb/${POKT_RPC_KEY}`,
+          http: `https://eth-goerli.rpc.grove.city/v1/${POKT_RPC_KEY}`,
+          webSocket: `wss://eth-goerli.rpc.grove.city/v1/${POKT_RPC_KEY}`,
         };
       case mainnet.id:
         return {
-          http: `https://eth-mainnet.rpc.grove.city/v1/lb/${POKT_RPC_KEY}`,
-          webSocket: `wss://eth-mainnet.rpc.grove.city/v1/lb/${POKT_RPC_KEY}`,
+          http: `https://eth-mainnet.rpc.grove.city/v1/${POKT_RPC_KEY}`,
+          webSocket: `wss://eth-mainnet.rpc.grove.city/v1/${POKT_RPC_KEY}`,
         };
       case sepolia.id:
         return {
-          http: `https://sepolia.rpc.grove.city/v1/lb/${POKT_RPC_KEY}`,
-          webSocket: `wss://sepolia.rpc.grove.city/v1/lb/${POKT_RPC_KEY}`,
+          http: `https://sepolia.rpc.grove.city/v1/${POKT_RPC_KEY}`,
+          webSocket: `wss://sepolia.rpc.grove.city/v1/${POKT_RPC_KEY}`,
         };
       default:
         return null;


### PR DESCRIPTION
It seems Grove City changed their API endpoints where it removed the `/lb/` part in their base URL. Also removed websocket to stop the constant fetch and error logs. I've added the change and fixed the balance querying issue. This is a hot fix and has not been fully tested end-to-end with executing bridge tx yet.

Please wait until a test is done to ensure the full bridge tx still works before merging this PR to production.