### PR TITLE
Change invalid POKT address toast with more context

### DIFF
--- a/context/Globals.tsx
+++ b/context/Globals.tsx
@@ -288,7 +288,7 @@ export function GlobalContextProvider({ children }: any) {
           <HStack spacing={4} padding={4} minW={330} bg="darkBlue" borderRadius={10} borderBottomColor="error" borderBottomWidth={1}>
             <ErrorIcon />
             <Text color="error">
-              Invalid POKT address! If you do not have one, please install{" "}
+              Invalid POKT address! It should start with "pokt" and be 43 characters long. If you do not have one, please install{" "}
               <Link href="https://trustsoothe.io/" textDecor="underline" isExternal>Soothe Vault</Link>
               {"."}
             </Text>

--- a/context/Globals.tsx
+++ b/context/Globals.tsx
@@ -318,7 +318,7 @@ export function GlobalContextProvider({ children }: any) {
   }
 
   function setPoktShannonAddress(address: string) {
-    const poktAddress = address.trim()
+    const poktAddress = address.trim().toLowerCase()
     try {
       if (!isPoktShannonAddress(poktAddress)) {
         throw new Error("Invalid POKT address")

--- a/utils/pokt.ts
+++ b/utils/pokt.ts
@@ -34,11 +34,10 @@ export function bech32ToHex(address: string): string {
 }
 
 export function isPoktShannonAddress(address: string): boolean {
-  const addr = address.trim().toLowerCase()
   return (
-    addr.startsWith(poktAddressPrefix) && 
-    addr.length === 43 && 
-    isAddress(bech32ToHex(addr))
+    address.startsWith(poktAddressPrefix) && 
+    address.length === 43 && 
+    isAddress(bech32ToHex(address))
   )
 }
 

--- a/utils/pokt.ts
+++ b/utils/pokt.ts
@@ -34,10 +34,11 @@ export function bech32ToHex(address: string): string {
 }
 
 export function isPoktShannonAddress(address: string): boolean {
+  const addr = address.trim().toLowerCase()
   return (
-    address.startsWith(poktAddressPrefix) && 
-    address.length === 43 && 
-    isAddress(bech32ToHex(address))
+    addr.startsWith(poktAddressPrefix) && 
+    addr.length === 43 && 
+    isAddress(bech32ToHex(addr))
   )
 }
 


### PR DESCRIPTION
This update to the error toast should provide more clarity for the user on what determines a valid POKT address.